### PR TITLE
Add Settings to toggle display example speech

### DIFF
--- a/web/lib/components/common/ToggleCheckbox.jsx
+++ b/web/lib/components/common/ToggleCheckbox.jsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export function ToggleCheckbox({ checked, onChange }) {
+  const [value, setValue] = useState(checked)
+
+  const doChange = (e) => {
+    setValue(e.target.checked)
+    onChange(e.target.checked)
+  }
+
+  return (
+    <div className="relative mr-2 inline-block w-10 select-none align-middle transition duration-200 ease-in">
+      <input
+        type="checkbox"
+        name="toggle"
+        id="toggle"
+        className="toggle-checkbox absolute block h-6 w-6 cursor-pointer appearance-none rounded-full border-4 bg-white"
+        checked={value}
+        onChange={doChange}
+      />
+      <label
+        htmlFor="toggle"
+        className="toggle-label block h-6 cursor-pointer overflow-hidden rounded-full bg-gray-300"></label>
+    </div>
+  )
+}

--- a/web/lib/components/common/ToggleCheckbox.jsx
+++ b/web/lib/components/common/ToggleCheckbox.jsx
@@ -1,10 +1,5 @@
-import { useState } from 'react'
-
 export function ToggleCheckbox({ checked, onChange }) {
-  const [value, setValue] = useState(checked)
-
   const doChange = (e) => {
-    setValue(e.target.checked)
     onChange(e.target.checked)
   }
 
@@ -15,7 +10,7 @@ export function ToggleCheckbox({ checked, onChange }) {
         name="toggle"
         id="toggle"
         className="toggle-checkbox absolute block h-6 w-6 cursor-pointer appearance-none rounded-full border-4 bg-white"
-        checked={value}
+        checked={checked}
         onChange={doChange}
       />
       <label

--- a/web/lib/components/nav/Settings.jsx
+++ b/web/lib/components/nav/Settings.jsx
@@ -28,8 +28,6 @@ export function Settings() {
     setSelected(e.target.value)
   }
 
-  const doToggleExampleSpeech = (value) => toggleShowExampleSpeech(value)
-
   return (
     <Fragment>
       <div className="grid items-center gap-2 lg:grid-cols-2">
@@ -51,7 +49,7 @@ export function Settings() {
           <div className="float-right">
             <ToggleCheckbox
               checked={showSpeechForExamples}
-              onChange={doToggleExampleSpeech}
+              onChange={toggleShowExampleSpeech}
             />
           </div>
         </div>

--- a/web/lib/components/nav/Settings.jsx
+++ b/web/lib/components/nav/Settings.jsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useState, useContext, Fragment } from 'react'
 import { useTranslation } from '../../i18n'
 import { getVoiceSettings } from '../../storage'
+import { ToggleCheckbox } from '../common/ToggleCheckbox'
+import { SettingsContext } from '../../context/Settings'
 
 export function Settings() {
   const { _e } = useTranslation()
@@ -16,24 +18,44 @@ export function Settings() {
     voiceSettings.get() ?? voices?.[0]?.voiceURI,
   )
 
+  const {
+    state: { showExampleSpeech },
+    toggleShowExampleSpeech,
+  } = useContext(SettingsContext)
+
   const doSetVoice = (e) => {
     voiceSettings.set(e.target.value)
     setSelected(e.target.value)
   }
 
+  const doToggleExampleSpeech = (value) => toggleShowExampleSpeech(value)
+
   return (
-    <div className="grid items-center gap-2 lg:grid-cols-2">
-      <div className="font-bold">{_e('nav.settings.voice')}</div>
-      <select
-        className="rounded border-gray-300 p-2 focus:border-indigo-500 focus:ring-indigo-500"
-        value={selected}
-        onChange={doSetVoice}>
-        {voices.map((voice) => (
-          <option value={voice.voiceURI} key={voice.voiceURI}>
-            {voice.name} - {_e('nav.settings.voice.' + voice.lang)}
-          </option>
-        ))}
-      </select>
-    </div>
+    <Fragment>
+      <div className="grid items-center gap-2 lg:grid-cols-2">
+        <div className="font-bold">{_e('nav.settings.voice')}</div>
+        <select
+          className="rounded border-gray-300 p-2 focus:border-indigo-500 focus:ring-indigo-500"
+          value={selected}
+          onChange={doSetVoice}>
+          {voices.map((voice) => (
+            <option value={voice.voiceURI} key={voice.voiceURI}>
+              {voice.name} - {_e('nav.settings.voice.' + voice.lang)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid items-center gap-2 lg:grid-cols-2">
+        <div className="font-bold">{_e('nav.settings.exampleSpeech')}</div>
+        <div>
+          <div className="float-right">
+            <ToggleCheckbox
+              checked={showExampleSpeech}
+              onChange={doToggleExampleSpeech}
+            />
+          </div>
+        </div>
+      </div>
+    </Fragment>
   )
 }

--- a/web/lib/components/nav/Settings.jsx
+++ b/web/lib/components/nav/Settings.jsx
@@ -19,7 +19,7 @@ export function Settings() {
   )
 
   const {
-    state: { showExampleSpeech },
+    settings: { showSpeechForExamples },
     toggleShowExampleSpeech,
   } = useContext(SettingsContext)
 
@@ -50,7 +50,7 @@ export function Settings() {
         <div>
           <div className="float-right">
             <ToggleCheckbox
-              checked={showExampleSpeech}
+              checked={showSpeechForExamples}
               onChange={doToggleExampleSpeech}
             />
           </div>

--- a/web/lib/components/word/Speech.jsx
+++ b/web/lib/components/word/Speech.jsx
@@ -10,7 +10,6 @@ export function Speech({ word }) {
   React.useEffect(() => {
     // Too bad window.speechSynthesis isn't widely supported yet on mobile
     if (!window.speechSynthesis) return
-
     const doGetVoices = () => {
       if (!window.speechSynthesis) return
 
@@ -24,10 +23,10 @@ export function Speech({ word }) {
     doGetVoices()
 
     // Cannot use `addEventListener` on iOS Safari T_T
-    window.speechSynthesis.voiceschanged = doGetVoices
+    window.speechSynthesis.onvoiceschanged = doGetVoices
 
     return () => {
-      window.speechSynthesis.voiceschanged = undefined
+      window.speechSynthesis.onvoiceschanged = undefined
     }
   }, [])
 

--- a/web/lib/components/word/Word.jsx
+++ b/web/lib/components/word/Word.jsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react'
 import { useTranslation } from '@/lib/i18n'
 
 import { LinkToWord } from '../common/LinkToWord'
@@ -6,9 +7,14 @@ import { VerbTenses } from './VerbTenses'
 import { Speech } from './Speech'
 import { DictMenu } from './DictMenu'
 import { Pronunciations } from './Pronunciations'
+import { SettingsContext } from '../../context/Settings'
 
 function Examples({ examples }) {
+  const {
+    state: { showExampleSpeech },
+  } = useContext(SettingsContext)
   const { _e } = useTranslation()
+
   return (
     <>
       <p className="upper-first mb-2 font-semibold text-slate-700">
@@ -21,6 +27,9 @@ function Examples({ examples }) {
             {ex.translation && (
               <span className="italic text-stone-700">= {ex.translation}</span>
             )}
+            <span className="float-right">
+              {showExampleSpeech && <Speech word={ex.text} />}
+            </span>
           </li>
         ))}
       </ul>

--- a/web/lib/components/word/Word.jsx
+++ b/web/lib/components/word/Word.jsx
@@ -11,7 +11,7 @@ import { SettingsContext } from '../../context/Settings'
 
 function Examples({ examples }) {
   const {
-    state: { showExampleSpeech },
+    settings: { showSpeechForExamples },
   } = useContext(SettingsContext)
   const { _e } = useTranslation()
 
@@ -28,7 +28,7 @@ function Examples({ examples }) {
               <span className="italic text-stone-700">= {ex.translation}</span>
             )}
             <span className="float-right">
-              {showExampleSpeech && <Speech word={ex.text} />}
+              {showSpeechForExamples && <Speech word={ex.text} />}
             </span>
           </li>
         ))}

--- a/web/lib/components/word/Word.jsx
+++ b/web/lib/components/word/Word.jsx
@@ -27,9 +27,11 @@ function Examples({ examples }) {
             {ex.translation && (
               <span className="italic text-stone-700">= {ex.translation}</span>
             )}
-            <span className="float-right">
-              {showSpeechForExamples && <Speech word={ex.text} />}
-            </span>
+            {showSpeechForExamples && (
+              <span className="float-right">
+                <Speech word={ex.text} />
+              </span>
+            )}
           </li>
         ))}
       </ul>

--- a/web/lib/context/Settings/index.jsx
+++ b/web/lib/context/Settings/index.jsx
@@ -1,22 +1,17 @@
-import { createContext, useState, useEffect } from 'react'
+import { createContext, useState } from 'react'
 import { getExampleSpeechSettings } from '../../storage'
 
 export const SettingsContext = createContext()
 
 export const SettingsProvider = ({ children }) => {
-  const [showSpeechForExamples, setShowSpeechForExamples] = useState(false)
+  const [showSpeechForExamples, setShowSpeechForExamples] = useState(
+    getExampleSpeechSettings().get(),
+  )
 
   const toggleShowExampleSpeech = (value) => {
     getExampleSpeechSettings().set(value)
     setShowSpeechForExamples(value)
   }
-
-  useEffect(() => {
-    setShowSpeechForExamples((prevState) => ({
-      ...prevState,
-      showSpeechForExamples: getExampleSpeechSettings().get(),
-    }))
-  }, [])
 
   return (
     <SettingsContext.Provider

--- a/web/lib/context/Settings/index.jsx
+++ b/web/lib/context/Settings/index.jsx
@@ -1,17 +1,22 @@
-import { createContext, useState } from 'react'
+import { createContext, useState, useEffect } from 'react'
 import { getExampleSpeechSettings } from '../../storage'
 
 export const SettingsContext = createContext()
 
 export const SettingsProvider = ({ children }) => {
-  const [showSpeechForExamples, setShowSpeechForExamples] = useState(
-    getExampleSpeechSettings().get(),
-  )
+  const [showSpeechForExamples, setShowSpeechForExamples] = useState(false)
 
   const toggleShowExampleSpeech = (value) => {
     getExampleSpeechSettings().set(value)
     setShowSpeechForExamples(value)
   }
+
+  useEffect(() => {
+    setShowSpeechForExamples((prevState) => ({
+      ...prevState,
+      showSpeechForExamples: getExampleSpeechSettings().get(),
+    }))
+  }, [])
 
   return (
     <SettingsContext.Provider

--- a/web/lib/context/Settings/index.jsx
+++ b/web/lib/context/Settings/index.jsx
@@ -1,0 +1,28 @@
+import { createContext, useState, useEffect } from 'react'
+import { getExampleSpeechSettings } from '../../storage'
+
+export const SettingsContext = createContext()
+
+export const SettingsProvider = ({ children }) => {
+  const [state, setState] = useState({
+    showExampleSpeech: false,
+  })
+
+  const toggleShowExampleSpeech = (value) => {
+    getExampleSpeechSettings().set(value)
+    setState({ ...setState, showExampleSpeech: value })
+  }
+
+  useEffect(() => {
+    setState((prevState) => ({
+      ...prevState,
+      showExampleSpeech: getExampleSpeechSettings().get(),
+    }))
+  }, [])
+
+  return (
+    <SettingsContext.Provider value={{ state, toggleShowExampleSpeech }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}

--- a/web/lib/context/Settings/index.jsx
+++ b/web/lib/context/Settings/index.jsx
@@ -4,24 +4,23 @@ import { getExampleSpeechSettings } from '../../storage'
 export const SettingsContext = createContext()
 
 export const SettingsProvider = ({ children }) => {
-  const [state, setState] = useState({
-    showExampleSpeech: false,
-  })
+  const [showSpeechForExamples, setShowSpeechForExamples] = useState(false)
 
   const toggleShowExampleSpeech = (value) => {
     getExampleSpeechSettings().set(value)
-    setState({ ...setState, showExampleSpeech: value })
+    setShowSpeechForExamples(value)
   }
 
   useEffect(() => {
-    setState((prevState) => ({
+    setShowSpeechForExamples((prevState) => ({
       ...prevState,
-      showExampleSpeech: getExampleSpeechSettings().get(),
+      showSpeechForExamples: getExampleSpeechSettings().get(),
     }))
   }, [])
 
   return (
-    <SettingsContext.Provider value={{ state, toggleShowExampleSpeech }}>
+    <SettingsContext.Provider
+      value={{ settings: { showSpeechForExamples }, toggleShowExampleSpeech }}>
       {children}
     </SettingsContext.Provider>
   )

--- a/web/lib/helpers.js
+++ b/web/lib/helpers.js
@@ -1,0 +1,3 @@
+export function isTrue(state) {
+  return state === 'true'
+}

--- a/web/lib/helpers.js
+++ b/web/lib/helpers.js
@@ -1,3 +1,0 @@
-export function isTrue(state) {
-  return state === 'true'
-}

--- a/web/lib/i18n/en.js
+++ b/web/lib/i18n/en.js
@@ -21,6 +21,7 @@ const messages = {
   'nav.settings.voice.en-IE': 'English (Ireland)',
   'nav.settings.voice.en-IN': 'English (India)',
   'nav.settings.voice.en-ZA': 'English (South Africa)',
+  'nav.settings.exampleSpeech': 'Show example speech',
 
   'word.seeAlso': 'See also',
   'word.examples': 'Examples',

--- a/web/lib/i18n/vi.js
+++ b/web/lib/i18n/vi.js
@@ -21,6 +21,7 @@ const messages = {
   'nav.settings.voice.en-IE': 'Giọng Anh Ireland',
   'nav.settings.voice.en-IN': 'Giọng Anh Ấn',
   'nav.settings.voice.en-ZA': 'Giọng Anh Nam Phi',
+  'nav.settings.exampleSpeech': 'Hiển thị đọc ví dụ',
 
   'word.seeAlso': 'Xem thêm',
   'word.examples': 'Ví dụ',

--- a/web/lib/storage.js
+++ b/web/lib/storage.js
@@ -1,8 +1,19 @@
+import { isTrue } from './helpers'
+
 export function getVoiceSettings() {
   const key = 'selected-voice'
 
   const get = () => window?.localStorage.getItem(key)
   const set = (uri) => window?.localStorage.setItem(key, uri)
+
+  return { get, set }
+}
+
+export function getExampleSpeechSettings() {
+  const key = 'show-example-speech'
+
+  const get = () => isTrue(window?.localStorage.getItem(key))
+  const set = (value) => window?.localStorage.setItem(key, value)
 
   return { get, set }
 }

--- a/web/lib/storage.js
+++ b/web/lib/storage.js
@@ -1,5 +1,3 @@
-import { isTrue } from './helpers'
-
 export function getVoiceSettings() {
   const key = 'selected-voice'
 
@@ -12,7 +10,7 @@ export function getVoiceSettings() {
 export function getExampleSpeechSettings() {
   const key = 'show-example-speech'
 
-  const get = () => isTrue(window?.localStorage.getItem(key))
+  const get = () => window?.localStorage.getItem(key) === 'true'
   const set = (value) => window?.localStorage.setItem(key, value)
 
   return { get, set }

--- a/web/pages/_app.jsx
+++ b/web/pages/_app.jsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 
 import '../styles/globals.css'
 import { Provider as IntlProvider } from '@/lib/i18n'
+import { SettingsProvider } from '@/lib/context/Settings'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,7 +16,9 @@ function MyApp({ Component, pageProps }) {
   return (
     <QueryClientProvider client={queryClient}>
       <IntlProvider>
-        <Component {...pageProps} />
+        <SettingsProvider>
+          <Component {...pageProps} />
+        </SettingsProvider>
       </IntlProvider>
     </QueryClientProvider>
   )

--- a/web/styles/atom.css
+++ b/web/styles/atom.css
@@ -1,3 +1,11 @@
 .upper-first::first-letter {
   text-transform: uppercase;
 }
+
+/* Toggle Checkbox */
+.toggle-checkbox:checked {
+  @apply right-0 border-sky-400;
+}
+.toggle-checkbox:checked + .toggle-label {
+  @apply bg-sky-400;
+}


### PR DESCRIPTION
- Add helper functions (value return from local storage is string 'true'/'false';
- Add function to `storage.js`to fetch settings
- Add ToggleCheckbox component with added styles into `atom.css`
- Add option to toggle display example speech into `Settings.jsx`
- Add Speech component at the end of each Example
- Add translaltions for settings name
- Add SettingsContext, Settings Provider to simutaneously show/hide Speech in example
- Fix `voiceschanged`to `onvoiceschanged``