### PR TITLE
Add condition to prevent delete default flashcard set.

### DIFF
--- a/web/lib/components/flashcards/query.js
+++ b/web/lib/components/flashcards/query.js
@@ -31,4 +31,4 @@ export const upsertFlashcard = (flashcard) =>
   sb.from(TBL_FLASHCARDS).upsert(flashcard, config)
 
 export const deleteFlashcards = ({ id }) =>
-  sb.from(TBL_FLASHCARDS).delete().match({ id })
+  sb.from(TBL_FLASHCARDS).delete().match({ id }).not('is_default', 'eq', true)

--- a/web/lib/components/flashcards/query.js
+++ b/web/lib/components/flashcards/query.js
@@ -22,7 +22,7 @@ export const getFlashcardSet = (
 export const upsertSet = (set) => sb.from(TBL_SETS).upsert(set, config)
 
 export const deleteFlashcardSet = ({ id }) =>
-  sb.from(TBL_SETS).delete().match({ id })
+  sb.from(TBL_SETS).delete().match({ id }).not('is_default', 'eq', true)
 
 export const getFlashcards = ({ setId }, { fields } = { fields: '*' }) =>
   sb.from(TBL_FLASHCARDS).select(fields, config).eq('set_id', setId)
@@ -31,4 +31,4 @@ export const upsertFlashcard = (flashcard) =>
   sb.from(TBL_FLASHCARDS).upsert(flashcard, config)
 
 export const deleteFlashcards = ({ id }) =>
-  sb.from(TBL_FLASHCARDS).delete().match({ id }).not('is_default', 'eq', true)
+  sb.from(TBL_FLASHCARDS).delete().match({ id })


### PR DESCRIPTION
- [x] Modify delete flashcard set query: not allow delete set with `is_default` equals to `true`