### PR TITLE
Add SQL queries for `flashcard_sets` and `flashcards` table

### DIFF
--- a/supabase/migrations/add_user_id_to_flashcards.sql
+++ b/supabase/migrations/add_user_id_to_flashcards.sql
@@ -5,4 +5,5 @@ UPDATE ONLY public.flashcards
   FROM (SELECT id, user_id FROM public.flashcard_sets) AS set
   WHERE set_id = set.id;
 
-ALTER TABLE public.flashcard_sets ALTER COLUMN user_id SET NOT NULL; 
+ALTER TABLE public.flashcard_sets ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE public.flashcard_sets ADD CONSTRAINT flashcards_user_id_fk FOREIGN KEY (user_id) REFERENCES auth.users(id) on DELETE CASCADE;

--- a/supabase/migrations/add_user_id_to_flashcards.sql
+++ b/supabase/migrations/add_user_id_to_flashcards.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.flashcards ADD COLUMN IF NOT EXISTS user_id uuid;
+
+UPDATE ONLY public.flashcards
+  SET user_id = set.user_id
+  FROM (SELECT id, user_id FROM public.flashcard_sets) AS set
+  WHERE set_id = set.id;
+
+ALTER TABLE public.flashcard_sets ALTER COLUMN user_id SET NOT NULL; 

--- a/supabase/migrations/limit_user_to_24_flashcard_sets.sql
+++ b/supabase/migrations/limit_user_to_24_flashcard_sets.sql
@@ -1,0 +1,19 @@
+DROP FUNCTION IF EXISTS check_user_flashcard_sets_amount CASCADE;
+CREATE OR REPLACE FUNCTION check_user_flashcard_sets_amount() RETURNS TRIGGER AS $fn$
+  DECLARE
+    rc int;
+  BEGIN
+    rc := (SELECT count(*) FROM public.flashcard_sets WHERE user_id = NEW.user_id); 
+    RAISE NOTICE 'number of rows %', rc;
+    IF rc >= 24 THEN
+      RAISE EXCEPTION 'User has exceed maximum number of allowed flashcard sets. %', rc;
+    END IF;
+    RETURN NEW;
+  END;
+$fn$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS validate_flashcard_sets_limit_trigger on public.flashcard_sets CASCADE;
+CREATE TRIGGER validate_flashcard_sets_limit_trigger
+  BEFORE INSERT ON public.flashcard_sets
+  FOR EACH ROW
+  EXECUTE FUNCTION check_user_flashcard_sets_amount();

--- a/supabase/migrations/limit_user_to_24_flashcard_sets.sql
+++ b/supabase/migrations/limit_user_to_24_flashcard_sets.sql
@@ -1,19 +1,37 @@
-DROP FUNCTION IF EXISTS check_user_flashcard_sets_amount CASCADE;
-CREATE OR REPLACE FUNCTION check_user_flashcard_sets_amount() RETURNS TRIGGER AS $fn$
-  DECLARE
-    rc int;
-  BEGIN
-    rc := (SELECT count(*) FROM public.flashcard_sets WHERE user_id = NEW.user_id); 
-    RAISE NOTICE 'number of rows %', rc;
-    IF rc >= 24 THEN
-      RAISE EXCEPTION 'User has exceed maximum number of allowed flashcard sets. %', rc;
-    END IF;
-    RETURN NEW;
-  END;
-$fn$ LANGUAGE plpgsql;
+-- DROP FUNCTION IF EXISTS check_user_flashcard_sets_amount CASCADE;
+-- CREATE OR REPLACE FUNCTION check_user_flashcard_sets_amount() RETURNS TRIGGER AS $fn$
+--   DECLARE
+--     rc int;
+--   BEGIN
+--     rc := (SELECT count(*) FROM public.flashcard_sets WHERE user_id = NEW.user_id); 
+--     RAISE NOTICE 'number of rows %', rc;
+--     IF rc >= 24 THEN
+--       RAISE EXCEPTION 'User has exceed maximum number of allowed flashcard sets. %', rc;
+--     END IF;
+--     RETURN NEW;
+--   END;
+-- $fn$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS validate_flashcard_sets_limit_trigger on public.flashcard_sets CASCADE;
-CREATE TRIGGER validate_flashcard_sets_limit_trigger
-  BEFORE INSERT ON public.flashcard_sets
-  FOR EACH ROW
-  EXECUTE FUNCTION check_user_flashcard_sets_amount();
+-- DROP TRIGGER IF EXISTS validate_flashcard_sets_limit_trigger on public.flashcard_sets CASCADE;
+-- CREATE TRIGGER validate_flashcard_sets_limit_trigger
+--   BEFORE INSERT ON public.flashcard_sets
+--   FOR EACH ROW
+--   EXECUTE FUNCTION check_user_flashcard_sets_amount();
+
+create or replace function limit_number_of_flashcards_fn() returns trigger as $fn$
+  declare
+    total int;
+  begin
+    select count(*) into total from public.flashcard_sets where user_id=new.user_id;
+
+    if total  >= 24 then
+      raise exception 'User has exceeded the amount of flashcard sets allowed (24).';
+    end if;
+
+    return new;
+  end;
+$fn$ language plpgsql;
+
+create trigger check_flashcard_sets_limit_trigger
+  before insert on public.flashcard_sets
+  for each row execute function limit_number_of_flashcards_fn();

--- a/supabase/migrations/limit_user_to_24_flashcard_sets.sql
+++ b/supabase/migrations/limit_user_to_24_flashcard_sets.sql
@@ -25,7 +25,9 @@ create or replace function limit_number_of_flashcards_fn() returns trigger as $f
     select count(*) into total from public.flashcard_sets where user_id=new.user_id;
 
     if total  >= 24 then
-      raise exception 'User has exceeded the amount of flashcard sets allowed (24).';
+      raise exception using
+        message='MAX_ALLOWED_SETS_CREATED',
+        hint='User has exceeded the amount of flashcard sets allowed (24).';
     end if;
 
     return new;

--- a/supabase/migrations/limit_user_to_24_flashcard_sets.sql
+++ b/supabase/migrations/limit_user_to_24_flashcard_sets.sql
@@ -1,23 +1,3 @@
--- DROP FUNCTION IF EXISTS check_user_flashcard_sets_amount CASCADE;
--- CREATE OR REPLACE FUNCTION check_user_flashcard_sets_amount() RETURNS TRIGGER AS $fn$
---   DECLARE
---     rc int;
---   BEGIN
---     rc := (SELECT count(*) FROM public.flashcard_sets WHERE user_id = NEW.user_id); 
---     RAISE NOTICE 'number of rows %', rc;
---     IF rc >= 24 THEN
---       RAISE EXCEPTION 'User has exceed maximum number of allowed flashcard sets. %', rc;
---     END IF;
---     RETURN NEW;
---   END;
--- $fn$ LANGUAGE plpgsql;
-
--- DROP TRIGGER IF EXISTS validate_flashcard_sets_limit_trigger on public.flashcard_sets CASCADE;
--- CREATE TRIGGER validate_flashcard_sets_limit_trigger
---   BEFORE INSERT ON public.flashcard_sets
---   FOR EACH ROW
---   EXECUTE FUNCTION check_user_flashcard_sets_amount();
-
 create or replace function limit_number_of_flashcards_fn() returns trigger as $fn$
   declare
     total int;

--- a/supabase/migrations/soft_delete_flashcard_sets.sql
+++ b/supabase/migrations/soft_delete_flashcard_sets.sql
@@ -12,7 +12,7 @@ ADD
 
 -- Create or replace function to soft delete public.flashcard_sets and public.flashcards
 CREATE
-OR REPLACE FUNCTION flashcard_sets_soft_delete() RETURNS TRIGGER AS $fn$
+OR REPLACE FUNCTION flashcard_sets_soft_delete_fn() RETURNS TRIGGER AS $fn$
   BEGIN
     UPDATE public.flashcard_sets SET deleted_at=now() WHERE id=OLD.id;
     UPDATE public.flashcards SET deleted_at=now() WHERE set_id=OLD.id;

--- a/supabase/migrations/soft_delete_flashcard_sets.sql
+++ b/supabase/migrations/soft_delete_flashcard_sets.sql
@@ -1,0 +1,59 @@
+-- Add is_deleted column to public.flashcard_sets
+ALTER TABLE
+  public.flashcard_sets
+ADD
+  COLUMN IF NOT EXISTS is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add deleted_at column to public.flashcard_sets
+ALTER TABLE
+  public.flashcard_sets
+ADD
+  COLUMN IF NOT EXISTS deleted_at timestamp WITH TIME ZONE;
+
+-- Add is_deleted column to public.flashcards
+ALTER TABLE
+  public.flashcards
+ADD
+  COLUMN IF NOT EXISTS is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add deleted_at column to public.flashcards
+ALTER TABLE
+  public.flashcards
+ADD
+  COLUMN IF NOT EXISTS deleted_at timestamp WITH TIME ZONE;
+
+-- Create or replace function to soft delete public.flashcard_sets and public.flashcards
+CREATE
+OR REPLACE FUNCTION flashcard_sets_soft_delete_fn() RETURNS TRIGGER AS $fn$
+  BEGIN
+    UPDATE public.flashcard_sets SET is_deleted=true, deleted_at=now() WHERE id=OLD.id;
+    UPDATE public.flashcards SET is_deleted=true, deleted_at=now() WHERE set_id=OLD.id;
+    RETURN NULL;
+  END;
+$fn$ LANGUAGE plpgsql;
+
+-- Drop trigger 'before delete public.flashcard_sets' before create
+DROP TRIGGER IF EXISTS flashcard_sets_soft_delete_trigger ON public.flashcard_sets CASCADE;
+
+-- Add trigger to before delete public.flashcard_sets
+CREATE TRIGGER flashcard_sets_soft_delete_trigger BEFORE DELETE ON public.flashcard_sets FOR EACH ROW EXECUTE FUNCTION flashcard_sets_soft_delete_fn();
+
+-- Create a view to hide deleted flashcard_sets
+CREATE
+OR REPLACE VIEW flashcard_sets_view AS
+SELECT
+  *
+FROM
+  public.flashcard_sets
+WHERE
+  is_deleted = false;
+
+-- Create a view to hide deleted flashcards
+CREATE
+OR REPLACE VIEW flashcards_view AS
+SELECT
+  *
+FROM
+  public.flashcards
+WHERE
+  is_deleted = false;

--- a/supabase/migrations/soft_delete_flashcard_sets.sql
+++ b/supabase/migrations/soft_delete_flashcard_sets.sql
@@ -2,13 +2,13 @@
 ALTER TABLE
   public.flashcard_sets
 ADD
-  COLUMN IF NOT EXISTS deleted_at timestampz;
+  COLUMN IF NOT EXISTS deleted_at timestamptz;
 
 -- Add deleted_at column to public.flashcards
 ALTER TABLE
   public.flashcards
 ADD
-  COLUMN IF NOT EXISTS deleted_at timestampz;
+  COLUMN IF NOT EXISTS deleted_at timestamptz;
 
 -- Create or replace function to soft delete public.flashcard_sets and public.flashcards
 CREATE

--- a/supabase/migrations/validate_flashcard_user_id.sql
+++ b/supabase/migrations/validate_flashcard_user_id.sql
@@ -5,7 +5,9 @@ create or replace function validate_upsert_flashcard_fn() returns trigger as $fn
     select user_id into setUserId from public.flashcard_sets where id=new.set_id;
     
     if setUserId <> new.user_id then
-      raise exception 'User not allow to modify flashcard in the other flashcard_set';
+      raise exception using
+        message='UNAUTHORIZED_MODIFY_FLASHCARDS',
+        hint='User not allow to modify flashcard in the other flashcard_set';
     end if;
 
     return new;

--- a/supabase/migrations/validate_flashcard_user_id.sql
+++ b/supabase/migrations/validate_flashcard_user_id.sql
@@ -1,0 +1,25 @@
+create or replace function validate_upsert_flashcard_fn() returns trigger as $fn$
+  declare
+    setUserId uuid;
+  begin
+    select user_id into setUserId from public.flashcard_sets where id=new.set_id;
+    
+    if setUserId <> new.user_id then
+      raise exception 'User not allow to modify flashcard in the other flashcard_set';
+    end if;
+
+    return new;
+  end;
+$fn$ language plpgsql;
+
+create trigger validate_before_insert_flashcard_trigger
+  before INSERT
+  on public.flashcards
+  FOR EACH row
+  execute function validate_upsert_flashcard_fn();
+
+create trigger validate_before_update_flashcard_trigger
+  before update
+  on public.flashcards
+  FOR EACH row
+  execute function validate_upsert_flashcard_fn();


### PR DESCRIPTION
## Tasks

- [x] Modify `pulbic.flashcards` (**supabase/migrations/add_user_id_to_flashcards.sql**)
	- add column *user_id* to `public.flashcards`
	- run update to add *user_id* to `public.flashcards`, of which *user_id* of `public.flashcard_sets` that flashcard belongs to.
	- set column *user_id* of `public.flashcards` to be `NOT NULL`
	- alter `user_id` column as foreign key to `auth.users`

- [x] Add trigger function to limit numbers of flashcard_sets can be created by user (**supabase/migrations/limit_user_to_24_flashcard_sets.sql**)
	- Add function to validate whether user has created more than 24 sets
	- Add trigger before insert into `public.flashcard_sets` using above declared function

- [x] Soft delete flashcard_sets, flashcards (**supabase/migrations/soft_delete_flashcard_sets.sql**)
	- Alter table columns of both flashcard_sets, flashcards
	- Create trigger function to soft delete flashcard_sets, flashcards
	- Add trigger function to before delete trigger
	- Create views for flashcard_sets, flashcards

- [ ] Actions
	- Migrate to production with above sql
	- Modify flashcard/flashcard_set - related hooks to add `user_id` as part of parameters
	- Properly display error message upon flashcard_sets creation error (native error or 24 sets limit error)